### PR TITLE
snap: drop GCONV_PATH, provided by the base snap now

### DIFF
--- a/scripts/bin/gpu-2404-provider-wrapper.in
+++ b/scripts/bin/gpu-2404-provider-wrapper.in
@@ -4,10 +4,6 @@ set -euo pipefail
 SELF="$( cd -- "$(dirname "$0")/.." ; pwd -P )/usr"
 ARCH_TRIPLETS=( @ARCH_TRIPLETS@ )
 
-if [ "$SNAP_ARCH" == "amd64" ]; then
-  GCONV_PATH=${GCONV_PATH:+$GCONV_PATH:}${SELF}/lib/i386-linux-gnu/gconv
-fi
-
 # VDPAU_DRIVER_PATH only supports a single path, rely on LD_LIBRARY_PATH instead
 for arch in ${ARCH_TRIPLETS[@]}; do
   LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${SELF}/lib/${arch}:${SELF}/lib/${arch}/vdpau
@@ -59,7 +55,6 @@ export __EGL_VENDOR_LIBRARY_DIRS
 export __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS
 export VK_LAYER_PATH
 export XDG_DATA_DIRS
-[ -z ${GCONV_PATH+x} ] || export GCONV_PATH
 export XLOCALEDIR
 
 exec "$@"


### PR DESCRIPTION
The base snap provides gconv for i386 as well now:

```
$ ls -1d /snap/core24/current/usr/lib/*/gconv
/snap/core24/current/usr/lib/i386-linux-gnu/gconv
/snap/core24/current/usr/lib/x86_64-linux-gnu/gconv
```