### PR TITLE
wrapper: move drirc.d and XErrorDB to environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Path|Description|Use
 --|--|--
 bin/gpu-2404-provider-wrapper|Sets up all the environment|Run your application through it
 ||
-drirc.d|App-specific workarounds|Layout to /usr/share/drirc.d
 libdrm|Needed by mesa on AMD GPUs|Layout to /usr/share/libdrm
 X11/XErrorDB|X11 locales etc|Layout to /usr/share/X11/XErrorDB
 ||

--- a/scripts/bin/gpu-2404-provider-wrapper.in
+++ b/scripts/bin/gpu-2404-provider-wrapper.in
@@ -12,6 +12,7 @@ for arch in ${ARCH_TRIPLETS[@]}; do
 done
 __EGL_VENDOR_LIBRARY_DIRS=${__EGL_VENDOR_LIBRARY_DIRS:+$__EGL_VENDOR_LIBRARY_DIRS:}${SELF}/share/glvnd/egl_vendor.d
 __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS=${__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:+$__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:}${SELF}/share/egl/egl_external_platform.d
+DRIRC_CONFIGDIR=${SELF}/drirc.d
 VK_LAYER_PATH=${VK_LAYER_PATH:+$VK_LAYER_PATH:}${SELF}/share/vulkan/implicit_layer.d/:${SELF}/share/vulkan/explicit_layer.d/
 XDG_DATA_DIRS=${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}${SELF}/share
 XLOCALEDIR="${SELF}/share/X11/locale"
@@ -53,6 +54,7 @@ if [ "${__NV_PRIME_RENDER_OFFLOAD:-}" != 1 ]; then
 fi
 export __EGL_VENDOR_LIBRARY_DIRS
 export __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS
+export DRIRC_CONFIGDIR
 export VK_LAYER_PATH
 export XDG_DATA_DIRS
 export XLOCALEDIR


### PR DESCRIPTION
Ref.:
- https://docs.mesa3d.org/envvars.html#envvar-DRIRC_CONFIGDIR

Unfotunately XErrorDB is not relocatable:
- https://bugs.freedesktop.org/show_bug.cgi?id=1980

Nor is libdrm:
- https://gitlab.freedesktop.org/mesa/drm/-/blob/main/amdgpu/amdgpu_asic_id.c#L116