### PR TITLE
Nvidia gbm

### DIFF
--- a/scripts/bin/gpu-2404-provider-wrapper.in
+++ b/scripts/bin/gpu-2404-provider-wrapper.in
@@ -45,6 +45,10 @@ if [ -d "/var/lib/snapd/lib/gl32/vdpau" ]; then
   LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/var/lib/snapd/lib/gl32/vdpau
 fi
 
+if [ -d "/var/lib/snapd/lib/gl/gbm" ]; then
+  GBM_BACKENDS_PATH=/var/lib/snapd/lib/gl/gbm
+fi
+
 export LD_LIBRARY_PATH
 export LIBGL_DRIVERS_PATH
 if [ "${__NV_PRIME_RENDER_OFFLOAD:-}" != 1 ]; then
@@ -55,6 +59,7 @@ fi
 export __EGL_VENDOR_LIBRARY_DIRS
 export __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS
 export DRIRC_CONFIGDIR
+export GBM_BACKENDS_PATH
 export VK_LAYER_PATH
 export XDG_DATA_DIRS
 export XLOCALEDIR

--- a/scripts/bin/gpu-2404-provider-wrapper.in
+++ b/scripts/bin/gpu-2404-provider-wrapper.in
@@ -46,7 +46,7 @@ if [ -d "/var/lib/snapd/lib/gl32/vdpau" ]; then
 fi
 
 if [ -d "/var/lib/snapd/lib/gl/gbm" ]; then
-  GBM_BACKENDS_PATH=/var/lib/snapd/lib/gl/gbm
+  export GBM_BACKENDS_PATH=/var/lib/snapd/lib/gl/gbm
 fi
 
 export LD_LIBRARY_PATH
@@ -59,7 +59,6 @@ fi
 export __EGL_VENDOR_LIBRARY_DIRS
 export __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS
 export DRIRC_CONFIGDIR
-export GBM_BACKENDS_PATH
 export VK_LAYER_PATH
 export XDG_DATA_DIRS
 export XLOCALEDIR

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -152,6 +152,18 @@ parts:
       - usr/share/doc/*/copyright
       - usr/share/egl/egl_external_platform.d
 
+  gbm:
+    # GBM EGL external platform
+    plugin: nil
+    stage-packages:
+      - to amd64:
+        - libnvidia-egl-gbm1
+      - to arm64:
+        - libnvidia-egl-gbm1
+    prime:
+      - usr/lib
+      - usr/share/egl/egl_external_platform.d
+
   apis-i386:
       # This provides the essential APIs
       #   o libGL.so.1
@@ -286,6 +298,7 @@ parts:
     - apis
     - drm
     - dri
+    - gbm
     - va
     - x11
     - wayland


### PR DESCRIPTION
* Support libgbm on NVIDIA

    NVIDIA now provides support for mesa's libgbm on nvidia-drm by
    implementing the gbm backend interface in a proprietary blob.
    An additional change is necessary in snapd to pull from the host the
    proprietary blob implementing the gbm backend interface for nvidia.
    Here set GBM_BACKENDS_PATH to the directory in which snapd will mount
    the library `nvidia-drm_gbm.so` (https://github.com/snapcore/snapd/pull/14256)

    This enables applications like Chromium to be GPU accelerated

* Support EGL_PLATFORM_GBM_KHR on NVIDIA
    
    This change enables support for EGL_PLATFORM_GBM_KHR
    (also knows as EGL_PLATFORM_GBM_MESA) on NVIDIA by providing:
     - /usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
     - /usr/lib/x86_64-linux-gnu/libnvidia-egl-gbm.so.1
    
    This requires $GBM_BACKENDS_PATH to be pointing to a directory
    containing the file `nvidia-drm_gbm.so`