### PR TITLE
Revert "snap: add X11 video drivers"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -129,7 +129,6 @@ parts:
       - libxdamage1
       - libxdmcp6
       - libxshmfence1
-      - xserver-xorg-video-all
     organize:
       # Expected at /X11/XErrorDB by the `gpu-2404` interface
       usr/share/X11/XErrorDB: X11/XErrorDB


### PR DESCRIPTION
This reverts commit 0f24fe2389980043e0396da31d4f28a93203a79f.

This was added as a mistake. No X11 server exists (is snapped) that could even use these - we never exposed the staged drivers in the environment in any way.

It won't affect consumer snaps as the [cleanup lists](https://github.com/canonical/gpu-snap/tree/main/lists) were not updated to include any of what was added as a result of this change.