### PR TITLE
ci: add refresh-downstreams workflow

### DIFF
--- a/.github/workflows/refresh-downstreams.yml
+++ b/.github/workflows/refresh-downstreams.yml
@@ -1,0 +1,36 @@
+name: Refresh downstreams
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  Refresh:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 5
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ref:
+        - asahi
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        # so that we know what to cherry-pick from
+        fetch-depth: 2
+
+    - name: Update `${{ matrix.ref }}`
+      env:
+        GIT_COMMITTER_NAME: "Mir CI Bot"
+        GIT_COMMITTER_EMAIL: "mir-ci-bot@canonical.com"
+      run: |
+        # bring upstream changes in
+        git fetch origin ${{ matrix.ref }}
+        git cherry-pick HEAD..origin/${{ matrix.ref }}
+
+        git push --force origin HEAD:${{ matrix.ref }}


### PR DESCRIPTION
So that `asahi` gets refreshed automatically.