### PR TITLE
Include libdrm-* drivers

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,6 +65,9 @@ parts:
     stage-packages:
       - libdrm2
       - libdrm-common
+      - libdrm-amdgpu1
+      - libdrm-nouveau2
+      - libdrm-radeon1
     organize:
       # Expected at /libdrm by the `gpu-2404` interface
       usr/share/libdrm: libdrm


### PR DESCRIPTION
They are required because *_dri.so from mesa are linked against them. Omitting them causes undefined symbol errors with newer versions.