### PR TITLE
Revert to using dpkg --add-architecture to add i386 repos

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,16 +31,15 @@ platforms:
   s390x:
   riscv64:
 
-package-repositories:
-  - type: apt
-    url: http://archive.ubuntu.com/ubuntu
-    suites: [jammy]
-    components: [main, universe]
-    architectures: [i386]
-    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
-    key-server: keyserver.ubuntu.com
-
 parts:
+  i386-repo:
+    plugin: nil
+    override-pull: |
+      if [ ${CRAFT_TARGET_ARCH} = "amd64" ]; then
+        dpkg --add-architecture i386
+        apt-get update
+      fi
+
   apis:
     # This provides the essential APIs
     #   o libGL.so.0
@@ -49,6 +48,7 @@ parts:
     #   o libvulkan.so.1
     #   o libgbm.so.1
     #
+    after: [i386-repo]  # because LP#2009278
     plugin: nil
     stage-packages:
       - libgl1
@@ -64,6 +64,7 @@ parts:
   drm:
     # DRM userspace
     #   o libdrm.so.2
+    after: [i386-repo]  # because LP#2009278
     plugin: nil
     stage-packages:
       - libdrm2
@@ -79,6 +80,7 @@ parts:
   va:
     # Video Acceleration API
     #   o libva.so.2
+    after: [i386-repo]  # because LP#2009278
     plugin: nil
     stage-packages:
       - libva2
@@ -91,6 +93,7 @@ parts:
 
   dri:
     # Userspace drivers
+    after: [i386-repo]  # because LP#2009278
     plugin: nil
     stage-packages:
       - libgl1-mesa-dri
@@ -115,6 +118,7 @@ parts:
   x11:
     # X11 support (not much cost to having this)
     #   o libGLX.so.0
+    after: [i386-repo]  # because LP#2009278
     plugin: nil
     stage-packages:
       - libglx0
@@ -139,6 +143,7 @@ parts:
 
   wayland:
     # Wayland support (not much cost to having this)
+    after: [i386-repo]  # because LP#2009278
     plugin: nil
     stage-packages:
       - libwayland-client0
@@ -153,6 +158,7 @@ parts:
 
   gbm:
     # GBM EGL external platform
+    after: [i386-repo]  # because LP#2009278
     plugin: nil
     stage-packages:
       - to amd64:
@@ -171,6 +177,7 @@ parts:
       #   o libvulkan.so.1
       #   o libgbm.so.1
       #
+    after: [i386-repo]  # because LP#2009278
     plugin: nil
     stage-packages:
       - on amd64:
@@ -189,6 +196,7 @@ parts:
   drm-i386:
     # DRM userspace
     #   o libdrm.so.2
+    after: [i386-repo]  # because LP#2009278
     plugin: nil
     stage-packages:
       - on amd64:
@@ -207,6 +215,7 @@ parts:
   va-i386:
     # Video Acceleration API
     #   o libva.so.2
+    after: [i386-repo]  # because LP#2009278
     plugin: nil
     stage-packages:
       - on amd64:
@@ -222,6 +231,7 @@ parts:
 
   dri-i386:
     # Userspace drivers
+    after: [i386-repo]  # because LP#2009278
     plugin: nil
     stage-packages:
       - on amd64:
@@ -249,6 +259,7 @@ parts:
   x11-i386:
     # X11 support (not much cost to having this)
     #   o libGLX.so.0
+    after: [i386-repo]  # because LP#2009278
     plugin: nil
     stage-packages:
       - on amd64:
@@ -277,6 +288,7 @@ parts:
 
   wayland-i386:
     # Wayland support (not much cost to having this)
+    after: [i386-repo]  # because LP#2009278
     plugin: nil
     stage-packages:
       - on amd64:


### PR DESCRIPTION
We should update the i386 repos from jammy to noble, however that fails:

E: Conflicting values set for option Signed-By regarding source http://archive.ubuntu.com/ubuntu/ noble: /etc/apt/keyrings/craft-991BC93C.gpg != /usr/share/keyrings/ubuntu-archive-keyring.gpg

This reverts commit 9bfae223707fdf2182b8d2d6d62fc3aaac16520b.

LP: #2083013