### PR TITLE
wrapper: fix DRIRC_CONFIGDIR

### DIFF
--- a/scripts/bin/gpu-2404-provider-wrapper.in
+++ b/scripts/bin/gpu-2404-provider-wrapper.in
@@ -12,7 +12,7 @@ for arch in ${ARCH_TRIPLETS[@]}; do
 done
 __EGL_VENDOR_LIBRARY_DIRS=${__EGL_VENDOR_LIBRARY_DIRS:+$__EGL_VENDOR_LIBRARY_DIRS:}${SELF}/share/glvnd/egl_vendor.d
 __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS=${__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:+$__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:}${SELF}/share/egl/egl_external_platform.d
-DRIRC_CONFIGDIR=${SELF}/drirc.d
+DRIRC_CONFIGDIR=$( cd -- "$(dirname "$0")/../drirc.d" ; pwd -P )
 VK_LAYER_PATH=${VK_LAYER_PATH:+$VK_LAYER_PATH:}${SELF}/share/vulkan/implicit_layer.d/:${SELF}/share/vulkan/explicit_layer.d/
 XDG_DATA_DIRS=${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}${SELF}/share
 XLOCALEDIR="${SELF}/share/X11/locale"


### PR DESCRIPTION
We have a spurious `usr/` there from `${SELF}`.