### PR TITLE
snap: add nouveau back

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -99,6 +99,9 @@ parts:
       - libvdpau-va-gl1
       - mesa-vulkan-drivers
       - libglx-mesa0
+      # This got refactored into libgallium, but to avoid it going missing on
+      # mesa-2404 refresh, bring it back explicitly
+      - libdrm-nouveau2
     organize:
       # Expected at /drirc.d by the `gpu-2404` interface
       usr/share/drirc.d: drirc.d
@@ -262,6 +265,8 @@ parts:
         - vdpau-driver-all:i386
         - mesa-vulkan-drivers:i386
         - libglx-mesa0:i386
+        # See `dri:` above
+        - libdrm-nouveau2:i386
     override-stage: |
       if [ `arch` = "x86_64" ]; then
         sed -i 's@/usr/lib/[a-z0-9_-]\+/@@' ${CRAFT_PART_INSTALL}/usr/share/vulkan/*/*.json
@@ -277,6 +282,14 @@ parts:
       - usr/share/vulkan
       - usr/share/doc/*/copyright
       - drirc.d
+      # The move from python3-minimal to python3 itself brought these in
+      # https://git.launchpad.net/ubuntu/+source/mesa/commit/debian?id=d052009df4038291bd330540594f2ace126b9cae
+      - -etc/apt
+      - -usr/bin/debconf*
+      - -usr/share/doc/debconf*
+      - -usr/share/lintian/overrides/debconf
+      - -usr/share/man/man1/debconf*
+      - -usr/share/man/man8/dpkg-*
 
   x11-i386:
     # X11 support (not much cost to having this)


### PR DESCRIPTION
In the recent Mesa update, it's no longer depended on by libgl1-mesa-dri.