### PR TITLE
snap: fix XLOCALEDIR across arches

### DIFF
--- a/scripts/bin/gpu-2404-provider-wrapper.in
+++ b/scripts/bin/gpu-2404-provider-wrapper.in
@@ -24,7 +24,7 @@ __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS=${__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:+$__EG
 DRIRC_CONFIGDIR=$( cd -- "$(dirname "$0")/../drirc.d" ; pwd -P )
 VK_LAYER_PATH=${VK_LAYER_PATH:+$VK_LAYER_PATH:}${SELF}/share/vulkan/implicit_layer.d/:${SELF}/share/vulkan/explicit_layer.d/
 XDG_DATA_DIRS=${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}${SELF}/share
-XLOCALEDIR=$( cd -- "$(dirname "$0")/../X11/locale" ; pwd -P )
+XLOCALEDIR=${SELF}/share/X11/locale
 
 # These are in the default LD_LIBRARY_PATH, but in case the snap dropped it inadvertently
 if [ -d "/var/lib/snapd/lib/gl" ] && [[ ! ${LD_LIBRARY_PATH} =~ (^|:)/var/lib/snapd/lib/gl(:|$) ]]; then

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -140,6 +140,7 @@ parts:
     prime:
       - usr/lib
       - usr/share/doc/*/copyright
+      - usr/share/X11/locale
       - X11
 
   wayland:
@@ -297,15 +298,11 @@ parts:
         - libxdamage1:i386
         - libxdmcp6:i386
         - libxshmfence1:i386
-    organize:
-      # Expected at /X11 by the `gpu-2404` interface
-      usr/share/X11: X11
     override-prime: |
       if [ `arch` = "x86_64" ]; then craftctl default; fi
     prime:
       - usr/lib
       - usr/share/doc/*/copyright
-      - X11
 
   wayland-i386:
     # Wayland support (not much cost to having this)


### PR DESCRIPTION
This isn't a dependency outside of amd64.

Fixes #63