### PR TITLE
snap: bring missing libs back and sanitize lists

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -337,7 +337,10 @@ parts:
     plugin: nil
     stage-packages:
       - libdrm-nouveau2
+      - libdrm-radeon1
+      - libglapi-mesa
       - libllvm17t64
+      - libllvm19
     prime:
       - usr/lib
       - usr/share/doc/*/copyright
@@ -347,7 +350,10 @@ parts:
     stage-packages:
       - on amd64:
         - libdrm-nouveau2:i386
+        - libdrm-radeon1:i386
+        - libglapi-mesa:i386
         - libllvm17t64:i386
+        - libllvm19:i386
         - libpciaccess0:i386
     override-prime: |
       if [ `arch` = "x86_64" ]; then craftctl default; fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -399,6 +399,7 @@ parts:
       cat <<EOF > ${CRAFT_PRIME}/snap/${CRAFT_ARCH_BUILD_FOR}.list
       usr/lib/*/dri/*
       usr/lib/*/libVkLayer_*.so
+      usr/lib/*/libgallium-*.so
       usr/lib/*/libvulkan_*.so
       usr/lib/*/vdpau/*
       usr/share/X11/locale/*
@@ -415,6 +416,7 @@ parts:
         -e dpkg-reconfigure                           # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1061658
         -e ^usr/lib/.*/dri/                           # Individual DRI and LibVA drivers
         -e ^usr/lib/.*/libVkLayer_.*.so               # Vulkan layer libraries
+        -e ^usr/lib/.*/libgallium-.*.so               # Mesa's shared infrastracture libraries
         -e ^usr/lib/.*/libvulkan_.*.so                # Individual Vulkan drivers
         -e ^usr/lib/.*/vdpau/                         # Individual VDPAU drivers
         -e ^usr/share/X11/locale/*                    # X11 locale files

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -401,6 +401,7 @@ parts:
       usr/lib/*/libVkLayer_*.so
       usr/lib/*/libvulkan_*.so
       usr/lib/*/vdpau/*
+      usr/share/X11/locale/*
       usr/share/drirc.d/*
       usr/share/egl/egl_external_platform.d/*
       usr/share/glvnd/egl_vendor.d/*
@@ -416,6 +417,7 @@ parts:
         -e ^usr/lib/.*/libVkLayer_.*.so               # Vulkan layer libraries
         -e ^usr/lib/.*/libvulkan_.*.so                # Individual Vulkan drivers
         -e ^usr/lib/.*/vdpau/                         # Individual VDPAU drivers
+        -e ^usr/share/X11/locale/*                    # X11 locale files
         -e ^usr/share/drirc.d/.*                      # Mesa quirk files
         -e ^usr/share/egl/egl_external_platform.d/.*  # EGL ICD files
         -e ^usr/share/glvnd/egl_vendor.d/*            # glvnd ICD files


### PR DESCRIPTION
A recent Mesa update brought LLVM 20, but we shouldn't have lost 19. Similarly, libglapi and libdrm_radeon fell off.

While here, modify a couple paths to be wildcards instead.

Ref.: https://github.com/canonical/gpu-snap/pull/51 for what the effect is, compared to https://github.com/canonical/gpu-snap/commit/5d4f4ffedd359c42ce22ad886744c6b73ca1e5da.