### PR TITLE
amdgpu: Add support for path envar

### DIFF
--- a/scripts/bin/gpu-2404-provider-wrapper.in
+++ b/scripts/bin/gpu-2404-provider-wrapper.in
@@ -9,7 +9,8 @@ if [ -f ${COMPONENT_PATH}/@COMPONENT_SENTINEL@ ]; then
   . ${COMPONENT_PATH}/@COMPONENT_MANGLER@
 fi
 
-SELF="$( cd -- "$(dirname "$0")/.." ; pwd -P )/usr"
+SELF_BASE="$( cd -- "$(dirname "$0")/.." ; pwd -P )"
+SELF=${SELF_BASE}/usr
 ARCH_TRIPLETS=( @ARCH_TRIPLETS@ )
 
 # VDPAU_DRIVER_PATH only supports a single path, rely on LD_LIBRARY_PATH instead
@@ -79,6 +80,6 @@ export XLOCALEDIR
 
 # Make use of the https://gitlab.freedesktop.org/mesa/libdrm/-/merge_requests/273 patch
 # in libdrm to find the amdgpu.ids file in other places
-export AMDGPU_ASIC_ID_TABLE_PATHS=${SNAP}/gpu-2404/libdrm:${SNAP}/usr/share/libdrm:${SNAP}/usr/local/share/libdrm:/usr/share/libdrm:/usr/local/share/libdrm
+export AMDGPU_ASIC_ID_TABLE_PATHS=${AMDGPU_ASIC_ID_TABLE_PATHS:+$AMDGPU_ASIC_ID_TABLE_PATHS:}${SELF_BASE}/libdrm
 
 exec "$@"

--- a/scripts/bin/gpu-2404-provider-wrapper.in
+++ b/scripts/bin/gpu-2404-provider-wrapper.in
@@ -77,4 +77,8 @@ export VK_LAYER_PATH
 export XDG_DATA_DIRS
 export XLOCALEDIR
 
+# Make use of the https://gitlab.freedesktop.org/mesa/libdrm/-/merge_requests/273 patch
+# in libdrm to find the amdgpu.ids file in other places
+export AMDGPU_ASIC_ID_TABLE_PATHS=${SNAP}/gpu-2404/libdrm:${SNAP}/usr/share/libdrm:${SNAP}/usr/local/share/libdrm:/usr/share/libdrm:/usr/local/share/libdrm
+
 exec "$@"


### PR DESCRIPTION
A new patch in libdrm allows to specify a set of paths where to search for the `amdgpu.ids` file. This patch configures the envar to search for the file directly in the mesa-2404 snap, and inside the posible locations inside the snap itself. This patch removes the need to bind the `amdgpu.ids` file into /usr/share/libdrm. Also, since it's only an envar, it can be added before the patch arrives the snap without breaking anything.

The libdrm patch: https://gitlab.freedesktop.org/mesa/libdrm/-/merge_requests/273