### PR TITLE
snap: include the whole libdrm stack

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,6 +68,24 @@ parts:
     stage-packages:
       - libdrm2
       - libdrm-common
+      - libdrm-amdgpu1
+      - libdrm-nouveau2
+      - libdrm-radeon1
+      - on amd64:
+        - libdrm-intel1
+      - on arm64:
+        - libdrm-etnaviv1
+        - libdrm-freedreno1
+        - libdrm-intel1
+        - libdrm-tegra0
+      - on armhf:
+        - libdrm-etnaviv1
+        - libdrm-exynos1
+        - libdrm-freedreno1
+        - libdrm-omap1
+        - libdrm-tegra0
+      - on riscv64:
+        - libdrm-intel1
     organize:
       # Expected at /libdrm by the `gpu-2404` interface
       usr/share/libdrm: libdrm
@@ -227,6 +245,10 @@ parts:
       - on amd64:
         - libdrm2:i386
         - libdrm-common
+        - libdrm-amdgpu1:i386
+        - libdrm-intel1:i386
+        - libdrm-nouveau2:i386
+        - libdrm-radeon1:i386
     override-prime: |
       if [ `arch` = "x86_64" ]; then craftctl default; fi
     organize:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -385,7 +385,8 @@ parts:
     override-prime: |
       set -eux
       cd /snap/core24/current
-      find . -type f,l -exec rm -f ${CRAFT_PRIME}/{} \;
+      # Keep libdrm in to avoid potentially mixing versions with the base snap
+      find . -type f,l -not -name 'libdrm*' -exec rm -f ${CRAFT_PRIME}/{} \;
       find ${CRAFT_PRIME} -empty -type d -delete
 
   file-list:
@@ -399,6 +400,7 @@ parts:
       cat <<EOF > ${CRAFT_PRIME}/snap/${CRAFT_ARCH_BUILD_FOR}.list
       usr/lib/*/dri/*
       usr/lib/*/libVkLayer_*.so
+      usr/lib/*/libdrm_*.so*
       usr/lib/*/libgallium-*.so
       usr/lib/*/libvulkan_*.so
       usr/lib/*/vdpau/*
@@ -416,6 +418,7 @@ parts:
         -e dpkg-reconfigure                           # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1061658
         -e ^usr/lib/.*/dri/                           # Individual DRI and LibVA drivers
         -e ^usr/lib/.*/libVkLayer_.*.so               # Vulkan layer libraries
+        -e ^usr/lib/.*/libdrm_.*.so*                  # libdrm userspace libraries
         -e ^usr/lib/.*/libgallium-.*.so               # Mesa's shared infrastracture libraries
         -e ^usr/lib/.*/libvulkan_.*.so                # Individual Vulkan drivers
         -e ^usr/lib/.*/vdpau/                         # Individual VDPAU drivers


### PR DESCRIPTION
This avoids potentially mixing libraries with the base snap.

Also ensure cleaning up libdrm userspace libraries from consumers.