### PR TITLE
snap: sanitize content source

### DIFF
--- a/scripts/bin/gpu-2404-provider-wrapper.in
+++ b/scripts/bin/gpu-2404-provider-wrapper.in
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# The second content element is mounted at "${content_target}-2"
-COMPONENT_PATH="$( cd -- "$(dirname "$0")"/.. ; pwd -P )-2"
+COMPONENT_PATH="$( cd -- "$(dirname "$0")"/.. ; pwd -P )/kernel-gpu-2404"
 
 # Use the component mangler to bootstrap the environment
 if [ -f ${COMPONENT_PATH}/@COMPONENT_SENTINEL@ ]; then
@@ -10,7 +9,7 @@ if [ -f ${COMPONENT_PATH}/@COMPONENT_SENTINEL@ ]; then
 fi
 
 SELF_BASE="$( cd -- "$(dirname "$0")/.." ; pwd -P )"
-SELF=${SELF_BASE}/usr
+SELF=${SELF_BASE}/mesa-2404/usr
 ARCH_TRIPLETS=( @ARCH_TRIPLETS@ )
 
 # VDPAU_DRIVER_PATH only supports a single path, rely on LD_LIBRARY_PATH instead
@@ -22,7 +21,7 @@ for arch in ${ARCH_TRIPLETS[@]}; do
 done
 __EGL_VENDOR_LIBRARY_DIRS=${__EGL_VENDOR_LIBRARY_DIRS:+$__EGL_VENDOR_LIBRARY_DIRS:}${SELF}/share/glvnd/egl_vendor.d
 __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS=${__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:+$__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:}${SELF}/share/egl/egl_external_platform.d
-DRIRC_CONFIGDIR=$( cd -- "$(dirname "$0")/../drirc.d" ; pwd -P )
+DRIRC_CONFIGDIR=${SELF_BASE}/drirc.d
 VK_LAYER_PATH=${VK_LAYER_PATH:+$VK_LAYER_PATH:}${SELF}/share/vulkan/implicit_layer.d/:${SELF}/share/vulkan/explicit_layer.d/
 XDG_DATA_DIRS=${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}${SELF}/share
 XLOCALEDIR=${SELF}/share/X11/locale

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -469,6 +469,13 @@ parts:
       | sort --unique \
       >> ${CRAFT_PRIME}/snap/${CRAFT_ARCH_BUILD_FOR}.list
 
+  organize:
+    after: [file-list]
+    plugin: nil
+    override-prime: |
+      mkdir --parents ${CRAFT_PRIME}/{mesa-2404,kernel-gpu-2404}
+      mv ${CRAFT_PRIME}/usr ${CRAFT_PRIME}/mesa-2404/
+
   scripts:
     after: [file-list]
     plugin: nil
@@ -502,9 +509,14 @@ plugs:
 slots:
   gpu-2404:
     interface: content
-    read:
-    - $SNAP
-    - $SNAP_DATA/kernel-gpu-2404
+    source:
+      read:
+      - $SNAP/bin
+      - $SNAP/drirc.d
+      - $SNAP/libdrm
+      - $SNAP/mesa-2404
+      - $SNAP/X11
+      - $SNAP_DATA/kernel-gpu-2404
 
 environment:
   COMPONENT_INTERFACE: kernel-gpu-2404


### PR DESCRIPTION
Avoid paths that would need to be dynamically created, avoiding issues with mount namespaces.