### PR TITLE
Revert "snap: sanitize content source (#104)"

### DIFF
--- a/scripts/bin/gpu-2404-provider-wrapper.in
+++ b/scripts/bin/gpu-2404-provider-wrapper.in
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-COMPONENT_PATH="$( cd -- "$(dirname "$0")"/.. ; pwd -P )/kernel-gpu-2404"
+# The second content element is mounted at "${content_target}-2"
+COMPONENT_PATH="$( cd -- "$(dirname "$0")"/.. ; pwd -P )-2"
 
 # Use the component mangler to bootstrap the environment
 if [ -f ${COMPONENT_PATH}/@COMPONENT_SENTINEL@ ]; then
@@ -9,7 +10,7 @@ if [ -f ${COMPONENT_PATH}/@COMPONENT_SENTINEL@ ]; then
 fi
 
 SELF_BASE="$( cd -- "$(dirname "$0")/.." ; pwd -P )"
-SELF=${SELF_BASE}/mesa-2404/usr
+SELF=${SELF_BASE}/usr
 ARCH_TRIPLETS=( @ARCH_TRIPLETS@ )
 
 # VDPAU_DRIVER_PATH only supports a single path, rely on LD_LIBRARY_PATH instead
@@ -20,7 +21,7 @@ for arch in ${ARCH_TRIPLETS[@]}; do
 done
 __EGL_VENDOR_LIBRARY_DIRS=${__EGL_VENDOR_LIBRARY_DIRS:+$__EGL_VENDOR_LIBRARY_DIRS:}${SELF}/share/glvnd/egl_vendor.d
 __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS=${__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:+$__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:}${SELF}/share/egl/egl_external_platform.d
-DRIRC_CONFIGDIR=${SELF_BASE}/drirc.d
+DRIRC_CONFIGDIR=$( cd -- "$(dirname "$0")/../drirc.d" ; pwd -P )
 VK_LAYER_PATH=${VK_LAYER_PATH:+$VK_LAYER_PATH:}${SELF}/share/vulkan/implicit_layer.d/:${SELF}/share/vulkan/explicit_layer.d
 XDG_DATA_DIRS=${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}${SELF}/share
 XLOCALEDIR=${SELF}/share/X11/locale

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -459,13 +459,6 @@ parts:
       | sort --unique \
       >> ${CRAFT_PRIME}/snap/${CRAFT_ARCH_BUILD_FOR}.list
 
-  organize:
-    after: [file-list]
-    plugin: nil
-    override-prime: |
-      mkdir --parents ${CRAFT_PRIME}/{mesa-2404,kernel-gpu-2404}
-      mv ${CRAFT_PRIME}/usr ${CRAFT_PRIME}/mesa-2404/
-
   scripts:
     after: [file-list]
     plugin: nil
@@ -499,14 +492,9 @@ plugs:
 slots:
   gpu-2404:
     interface: content
-    source:
-      read:
-      - $SNAP/bin
-      - $SNAP/drirc.d
-      - $SNAP/libdrm
-      - $SNAP/mesa-2404
-      - $SNAP/X11
-      - $SNAP_DATA/kernel-gpu-2404
+    read:
+    - $SNAP
+    - $SNAP_DATA/kernel-gpu-2404
 
 environment:
   COMPONENT_INTERFACE: kernel-gpu-2404


### PR DESCRIPTION
This reverts commit 8323e28e3e890c7ebafd76161351a57618b9bc0b, reversing changes made to bc8b2380f360e0150a703bb026e541ac491f6827.

There's downstream snaps that relied on the original layout, this gives them time to avoid assuming paths we don't consider part of the contract, and use the wrapper instead.